### PR TITLE
Support beautification of HTTP 100 responses.

### DIFF
--- a/curlish.py
+++ b/curlish.py
@@ -561,12 +561,12 @@ def beautify_curl_output(iterable, hide_headers, hide_jsonp=False):
     # Headers
     for line in iterable:
         if re.search(r'^HTTP/', line):
-            if re.search('HTTP/\d+.\d+ 100', line):
+            if re.search('HTTP/\d+.\d+\s+100', line):
                 continuing = True
             elif continuing:
                 continuing = False
             if has_colors and not hide_headers:
-                if re.search('HTTP/\d+.\d+ [45]\d+', line):
+                if re.search('HTTP/\d+.\d+\s+[45]\d+', line):
                     color = get_color('statusline_error')
                 else:
                     color = get_color('statusline_ok')


### PR DESCRIPTION
Detect when the server sends an `HTTP 100 (Continue)` response header
and kick our beautification loop into 'continuing' mode.  While in
this mode, we wait for another `^HTTP/` header to be received before
responding to the `\r\n` break sequence signalling the end of the
headers and the start of the body.  This gives us output like:

```
HTTP/1.1 100 (Continue)

HTTP/1.1 200 OK
Content-Length: 387
Content-Type: application/json; charset=UTF-8

{
}
```

This comes into play when uploading files using curlish.

Previously, these types of HTTP conversations were not "beautified"
because the header processing loop bailed out after the initial
`HTTP/1.1 100 (Continue)\r\n\r\n` content was handled.
