### PR TITLE
OAuth 1.0a a.k.a. OAuth 1.0 a.k.a. RFC 5849

### DIFF
--- a/curlish.py
+++ b/curlish.py
@@ -235,7 +235,8 @@ class AuthorizationHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.server.token_response = dict((k, v[-1]) for k, v in
             cgi.parse_qs(self.path.split('?')[-1]).iteritems())
-        if 'code' in self.server.token_response:
+        if 'code' in self.server.token_response or \
+           'oauth_verifier' in self.server.token_response:
             title = 'Tokens Received'
             text = 'The tokens were transmitted successfully to curlish.'
         else:

--- a/curlish.py
+++ b/curlish.py
@@ -66,7 +66,12 @@ from getpass import getpass
 from uuid import UUID
 import logging
 
-from oauthlib.oauth1.rfc5849 import Client as OAuth1
+try:
+    from oauthlib.oauth1.rfc5849 import Client as OAuth1
+except ImportError:
+    class OAuth1(object):
+        def __init__(*args, **kwargs):
+            raise NotImplementedError('RFC 5849 authorization requires oauthlib')
 
 
 def str_to_uuid(s):

--- a/curlish.py
+++ b/curlish.py
@@ -345,18 +345,25 @@ class Site(object):
         real_headers.update(headers or ())
 
         uri = u.path + ('?' + u.query if u.query else '')
+        logger.debug('Request: {0} {1}'.format(method, url))
+        logger.debug('Request headers: {0}'.format(real_headers))
+        logger.debug('Request body: {0}'.format(data))
         conn.request(method, uri, data, real_headers)
         resp = conn.getresponse()
+        resp_body = resp.read()
+        logger.debug('Response status: {0}'.format(resp.status))
+        logger.debug('Response headers: {0}'.format(resp.getheaders()))
+        logger.debug('Response body: {0}'.format(resp_body))
 
         ct = resp.getheader('Content-Type')
         if ct.startswith('application/json') or ct.startswith('text/javascript'):
-            resp_data = json.loads(resp.read())
+            resp_data = json.loads(resp_body)
         else:
             if not ct.startswith('application/x-www-form-urlencoded'):
                 logger.info('Unexpected Content-Type from server: ' + ct + '. Trying to continue anyway.')
 
             resp_data = dict((k, v[-1]) for k, v in
-                cgi.parse_qs(resp.read()).iteritems())
+                             cgi.parse_qs(resp_body).iteritems())
 
         return resp.status, resp_data
 
@@ -452,7 +459,7 @@ class Site(object):
             u'POST',
             body='',
             headers={'Content-Type': 'application/x-www-form-urlencoded',
-                     'Accept': 'applicaiton/x-www-form-urlencoded'},
+                     'Accept': 'application/x-www-form-urlencoded'},
             realm=None)
 
         rdata = self.get_rfc5849_request_token(body, headers)

--- a/curlish.py
+++ b/curlish.py
@@ -422,17 +422,40 @@ class Site(object):
             print '  %s: %s' % (key, value)
         sys.exit(1)
 
+    def get_rfc5849_request_token(self, params):
+        """Tries to load tokens with the given parameters."""
+        data = params
+        headers = { 'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8' }
+        status, data = self.make_request('POST',
+                                         self.request_token_url, data=data, headers=headers)
+        import pdb; pdb.set_trace()
+
+        if status == 200:
+            return data['access_token']
+        error = data.get('error')
+        if error in ('invalid_grant', 'access_denied'):
+            return None
+        error_msg = data.get('error_description')
+        fail("Couldn't authorize: %s - %s" % (error, error_msg))
+
     def request_rfc5849_authorization_code_grant(self):
-        queryoauth = OAuth1(self.client_id, self.client_secret)
-
         redirect_uri = u'http://127.0.0.1:%d/' % settings.values['http_port']
+        oauth = OAuth1(self.client_id, self.client_secret, callback_uri=redirect_uri,
+                       signature_type=self.signature_type)
+        import pdb; pdb.set_trace()
+        (request_token_url, headers, body) = oauth.client.sign(
+            unicode(self.request_token_url),
+            u'POST',
+            body='',
+            headers={'Content-Type': 'application/x-www-form-urlencoded'},
+            realm=None)
 
-        r = requests.post(
-            self.request_token_url,
-            auth=OAuth1(self.client_id, self.client_secret, callback_uri=redirect_uri,
-                        signature_type=self.signature_type),
-            headers={'Content-Type': 'application/x-www-form-urlencoded'})
-        
+        import pdb; pdb.set_trace()
+
+        result = self.get_rfc5849_request_token(body)
+
+        import pdb; pdb.set_trace()
+
         logger.debug('Request temporary credentials: {0}'.format(r.request.__dict__))
         logger.debug('Temporary credentials response: {0}'.format(r.__dict__))
         

--- a/curlish.py
+++ b/curlish.py
@@ -421,9 +421,6 @@ class Site(object):
         sys.exit(1)
 
     def request_rfc5849_authorization_code_grant(self):
-        logger = logging.getLogger(__name__)
-        logging.basicConfig(level='DEBUG')
-        
         queryoauth = OAuth1(self.client_id, self.client_secret)
 
         redirect_uri = u'http://127.0.0.1:%d/' % settings.values['http_port']
@@ -996,6 +993,9 @@ def main():
     parser.add_argument('--clear-cookies', action='store_true',
                         help='Deletes all the cookies or cookies that belong '
                              'to one specific site only.')
+    parser.add_argument('--logging-level',
+                        help='Log output with the given logging level, '
+                             'e.g., DEBUG, INFO, etc.')
     parser.add_argument('--dump-curl-args', action='store_true',
                         help='Instead of executing dump the curl command line '
                              'arguments for this call')
@@ -1030,6 +1030,9 @@ def main():
         clear_cookies(args.site)
         return
 
+    if args.logging_level:
+        logging.basicConfig(level=args.logging_level)
+
     # Redirect everything else to curl via the site
     url_arg = find_url_arg(extra_args)
     if url_arg is None:
@@ -1051,10 +1054,10 @@ def main():
                 site.client_secret,
                 site.access_token,
                 site.access_token_secret))
-        logger = logging.getLogger(__name__)
-        logging.basicConfig(level='DEBUG')
         logger.debug('{0}'.format(r.request.__dict__))
         logger.debug('{0}'.format(r.__dict__))
+
+logger = logging.getLogger(__name__)
 
 if __name__ == '__main__':
     try:

--- a/curlish.py
+++ b/curlish.py
@@ -224,6 +224,12 @@ def find_url_arg(arguments):
         if arg.startswith(('http:', 'https:')):
             return idx
 
+def find_method_arg(arguments):
+    """Finds the HTTP method argument in acurl argument list."""
+    for idx, arg in enumerate(arguments):
+        if arg == '-X':
+            return idx + 1
+
 
 class AuthorizationHandler(BaseHTTPRequestHandler):
     """Callback handler for the code based authorization"""
@@ -1096,9 +1102,14 @@ def main():
             site.access_token,
             site.access_token_secret,
             signature_type='QUERY')
+        method_arg = find_method_arg(extra_args)
+        if method_arg is None:
+            method = 'GET'
+        else:
+            method = extra_args[method_arg]
         (extra_args[url_arg], headers, body) = oauth.sign(
             unicode(extra_args[url_arg]),
-            u'GET',
+            unicode(method),
             body=None,
             headers=None,
             realm=None)

--- a/curlish.py
+++ b/curlish.py
@@ -66,8 +66,7 @@ from getpass import getpass
 from uuid import UUID
 import logging
 
-import requests
-from requests.auth import OAuth1
+from oauthlib.oauth1.rfc5849 import Client as OAuth1
 
 
 def str_to_uuid(s):
@@ -442,7 +441,7 @@ class Site(object):
         redirect_uri = u'http://127.0.0.1:%d/' % settings.values['http_port']
         oauth = OAuth1(self.client_id, self.client_secret, callback_uri=redirect_uri,
                        signature_type=self.signature_type)
-        (request_token_url, headers, body) = oauth.client.sign(
+        (request_token_url, headers, body) = oauth.sign(
             unicode(self.request_token_url),
             u'POST',
             body='',
@@ -497,8 +496,7 @@ class Site(object):
                        unicode(request_token),
                        unicode(request_token_secret),
                        callback_uri=redirect_uri, signature_type=self.signature_type)
-        import pdb; pdb.set_trace()
-        (access_token_url, headers, body) = oauth.client.sign(
+        (access_token_url, headers, body) = oauth.sign(
             unicode(self.access_token_url),
             u'POST',
             body=data,
@@ -1097,7 +1095,7 @@ def main():
             site.access_token,
             site.access_token_secret,
             signature_type='QUERY')
-        (extra_args[url_arg], headers, body) = oauth.client.sign(
+        (extra_args[url_arg], headers, body) = oauth.sign(
             unicode(extra_args[url_arg]),
             u'GET',
             body=None,

--- a/curlish.py
+++ b/curlish.py
@@ -1056,6 +1056,7 @@ def main():
                 site.access_token_secret))
         logger.debug('{0}'.format(r.request.__dict__))
         logger.debug('{0}'.format(r.__dict__))
+        sys.stdout.write(r.text)
 
 logger = logging.getLogger(__name__)
 

--- a/curlish.py
+++ b/curlish.py
@@ -1052,11 +1052,7 @@ def main():
     if site is not None and site.grant_type is not None:
         site.fetch_token_if_necessarys()
     settings.save()
-    if site.oauth_version == '2.0':
-        invoke_curl(site, settings.values['curl_path'], extra_args, url_arg,
-                    dump_args=args.dump_curl_args,
-                    dump_response=args.dump_response)
-    elif site.oauth_version == 'rfc5849':
+    if site.oauth_version == 'rfc5849':
         oauth = OAuth1(
             site.client_id,
             site.client_secret,
@@ -1070,9 +1066,9 @@ def main():
             headers=None,
             realm=None)
         logger.debug('Signed request URL: {0}'.format(extra_args[url_arg]))
-        invoke_curl(site, settings.values['curl_path'], extra_args, url_arg,
-                    dump_args=args.dump_curl_args,
-                    dump_response=args.dump_response)
+    invoke_curl(site, settings.values['curl_path'], extra_args, url_arg,
+                dump_args=args.dump_curl_args,
+                dump_response=args.dump_response)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
@mitsuhiko We had a brief [conversation](https://twitter.com/mitsuhiko/statuses/186132512517525504) on Twitter.

Here's a proof of concept using [oauthlib](https://github.com/idan/oauthlib) via [requests](https://github.com/kennethreitz/requests).

A `.ftcurlish.json`: https://gist.github.com/4158445.

And a demonstration using Twitter: https://gist.github.com/4158502.

This is obviously not ready to merge. Just starting a conversation. Requests has a nice high level API, but I imagine you might not like that dependency. Maybe using oauthlib directly to sign requests and then passing its output to curl would be better.

What do you think?
